### PR TITLE
Fix default currency on transactions

### DIFF
--- a/lib/sps_king/transaction.rb
+++ b/lib/sps_king/transaction.rb
@@ -43,7 +43,7 @@ module SPS
       self.requested_date ||= DEFAULT_REQUESTED_DATE
       self.reference ||= 'NOTPROVIDED'
       self.batch_booking = true if self.batch_booking.nil?
-      self.currency ||= 'EUR'
+      self.currency ||= 'CHF'
     end
 
     protected


### PR DESCRIPTION
Resolves #4 

The official currency in switzerland is CHF and the default, as also stated in the documentation, makes sense to be set to CHF.

This will resolve it