### PR TITLE
fix(README): broken code in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ sdd.add_transaction(
 
   # OPTIONAL: Requested collection date, in German "Fälligkeitsdatum der Lastschrift"
   # Date
-  requested_date: Date.new(2013,9,5),
+  requested_date: Date.new(2013, 9, 5),
 
   # OPTIONAL: Use a different creditor account
   # CreditorAccount
@@ -212,7 +212,7 @@ sct.add_transaction(
   # One of these strings:
   #   'SEPA' ("SEPA-Zahlung")
   #   'URGP' ("Taggleiche Eilüberweisung")
-  service_level: 'URGP'
+  service_level: 'URGP',
 
   # OPTIONAL: Charge Bearer
   # One of these strings:


### PR DESCRIPTION
## Why

I stumbled on these very minor broken code examples in the README.md

Instead of writing an issue, I just created this PR to fix it.

Additionally, I added two H3 headers, to make navigating the README.md a bit more convenient.

TIA.

## Commits

## fix(README): broken code in usage examples

f80329c2da5952302f556de81c0e0d434953bdbc

The code examples have missing `,` and thus are broken.

## docs(README): add usage example h3 navigation headers

ef1c565aba7086894e1ba3f2cdd92bd3e45c6398

This makes reading the README easier with GitHub header navigation TOC.
