### PR TITLE
refactor(convert_decimal): make pure, more explicit, and improve spec

### DIFF
--- a/lib/sps_king/converter.rb
+++ b/lib/sps_king/converter.rb
@@ -37,16 +37,15 @@ module SPS
           strip
       end
 
+      # @param [BigDecimal|Integer|Float|String|nil] value the value to convert
+      # @return [BigDecimal|nil] the converted value or nil if the conversion failed
       def convert_decimal(value)
-        return unless value
-        value = begin
-          BigDecimal(value.to_s)
-        rescue ArgumentError
-        end
-
-        if value && value.finite? && value > 0
-          value.round(2)
-        end
+        val = begin
+                BigDecimal(value.to_s)
+              rescue ArgumentError
+                nil
+              end
+        val.round(2) if val&.finite? && val > 0
       end
     end
   end

--- a/spec/lib/sps_king/converter_spec.rb
+++ b/spec/lib/sps_king/converter_spec.rb
@@ -63,6 +63,14 @@ describe SPS::Converter do
       expect(convert_decimal(42.12)).to eq(BigDecimal('42.12'))
     end
 
+    it "should convert numeric string to BigDecimal" do
+      expect(convert_decimal('35.21')).to eq(BigDecimal('35.21'))
+    end
+
+    it "should keep BigDecimal" do
+      expect(convert_decimal(BigDecimal('55.01'))).to eq(BigDecimal('55.01'))
+    end
+
     it 'should round' do
       expect(convert_decimal(1.345)).to eq(BigDecimal('1.35'))
     end
@@ -81,8 +89,17 @@ describe SPS::Converter do
 
     it 'should not convert invalid value' do
       expect(convert_decimal('xyz')).to eq(nil)
-      expect(convert_decimal('NaN')).to eq(nil)
-      expect(convert_decimal('Infinity')).to eq(nil)
+      expect(convert_decimal([12.2])).to eq(nil)
+      expect(convert_decimal({ value: '1.1' })).to eq(nil)
+      expect(convert_decimal(Date.new(2025))).to eq(nil)
+      expect(convert_decimal(1..10)).to eq(nil)
+      expect(convert_decimal(Float::INFINITY)).to eq(nil)
+    end
+
+    it "should not convert NaN value" do
+      nan_value = 0.0 / 0
+      expect(nan_value).to be_nan
+      expect(convert_decimal(nan_value)).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
- remove parameter overwrite
- explicit BigDecimal create guard to nil
- val.positive? instead of val > 0
- more code style sane
- spec improvements
  - add missing spec for numeric string input
  - add missing spec for BigDecimal input
  - invalid value NaN tests for actual NaN, not string 'NaN'
  - invalid value Infinity tests for actual Infinity instead of string 'Infinity'
  - invalid Date, Hash, and Array inputs


## Why

I was looking around the code with the intention to create rbs sigs for the lib.  

There I stumbled on #convert_decimal, and could not instantly understand what it's supposed to do and why.

Fiddling around with it, I got it, but thought I might contribute this as a code quality improvement.

Use my contribution if you like it, or discard it if you don't agree with my understanding of code quality.
Either way, I won't see any offence if you don't want the changes.


