### PR TITLE
Compatibility for Credit transfers v1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ xml_string = sdd.to_xml # Use latest schema pain.008.001.02.ch.03
 How to create the XML for **Credit Transfer Initiation** (in German: "Überweisungen")
 
 ```ruby
+# NOTE: Now that Swiss Implementation v1.9 `pain.001.001.09.ch.02` is now supported for Credit Transfers
+# To use the Swiss Implementation v1.9 schema, You need to pass an attribute " schema_version: :V9" to SPS::CreditTransfer.new
+# If schema_version is provided then it uses v1.9 `pain.001.001.09.ch.02`, else it uses v1.8 `pain.001.001.03.ch.02`
+
 # First: Create the main object
 sct = SPS::CreditTransfer.new(
   # Name of the initiating party and debtor, in German: "Auftraggeber"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Gem Version](https://badge.fury.io/rb/sps_king.svg)](http://badge.fury.io/rb/sps_king)
 
 sps_king is a Ruby gem which implements **pain** (**Pa**yment **In**itiation) file building for the Swiss Payment Standard, which is a subset of the ISO 20022 standard.
-This is currently implemented in v1.8 for Swiss Credit Transfers (`pain.001.001.03.ch.02`) and v1.2 for Swiss Direct Debits (`pain.008.001.02.ch.03`).
+This is currently implemented in v1.8 for Swiss Credit Transfers (`pain.001.001.03.ch.02`) and we have added patch making it compatible for v1.9 Swiss Credit Transfers (`pain.001.001.09.ch.03`) and v1.2 for Swiss Direct Debits (`pain.008.001.02.ch.03`).
 
 If you are looking for SEPA **pain** file building, take a look at [sepa_king](https://github.com/salesking/sepa_king).
 This gem is forked of `sepa_king` and therefore heavily inspired by the structure and the API.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ How to create the XML for **Credit Transfer Initiation** (in German: "Überweisu
 
 ```ruby
 # NOTE: Now that Swiss Implementation v1.9 `pain.001.001.09.ch.02` is now supported for Credit Transfers
-# To use the Swiss Implementation v1.9 schema, You need to pass an attribute " schema_version: :V9" to SPS::CreditTransfer.new
+# To use the Swiss Implementation v1.9 schema, You need to pass an attribute " schema_version: :pain_001_001_09_ch_03" to SPS::CreditTransfer.new
 # If schema_version is provided then it uses v1.9 `pain.001.001.09.ch.02`, else it uses v1.8 `pain.001.001.03.ch.02`
 
 # First: Create the main object

--- a/lib/schema/pain.001.001.09.ch.03.xsd
+++ b/lib/schema/pain.001.001.09.ch.03.xsd
@@ -1,0 +1,1733 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+(C) Copyright 2021, SIX, www.iso-payments.ch
+CH Version for pain.001 Credit Transfer: "pain.001.001.09.ch.03.xsd"
+.ch.:	            Identification for this CH version
+Last part (.03):   CH Version of this scheme
+
+Based on ISO pain.001.001.09 (urn:iso:std:iso:20022:tech:xsd:pain.001.001.09)
+-->
+<xs:schema xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09" elementFormDefault="qualified">
+	<xs:element name="Document" type="Document_pain001_ch"/>
+	<xs:complexType name="AccountIdentification4Choice">
+		<xs:choice>
+			<xs:element name="IBAN" type="IBAN2007Identifier"/>
+			<xs:element name="Othr" type="GenericAccountIdentification1"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="AccountIdentification4Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="AccountIdentification4Choice">
+				<xs:choice>
+					<xs:element name="IBAN" type="IBAN2007Identifier"/>
+					<xs:element name="Othr" type="GenericAccountIdentification1_pain001_ch"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AccountSchemeName1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalAccountIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ActiveOrHistoricCurrencyAndAmount">
+		<xs:simpleContent>
+			<xs:extension base="ActiveOrHistoricCurrencyAndAmount_SimpleType">
+				<xs:attribute name="Ccy" type="ActiveOrHistoricCurrencyCode" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyAndAmount_SimpleType">
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0"/>
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="5"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{3,3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AddressType2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ADDR"/>
+			<xs:enumeration value="BIZZ"/>
+			<xs:enumeration value="DLVY"/>
+			<xs:enumeration value="HOME"/>
+			<xs:enumeration value="MLTO"/>
+			<xs:enumeration value="PBOX"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AddressType3Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="AddressType2Code"/>
+			<xs:element name="Prtry" type="GenericIdentification30"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="AmountType4Choice">
+		<xs:choice>
+			<xs:element name="InstdAmt" type="ActiveOrHistoricCurrencyAndAmount"/>
+			<xs:element name="EqvtAmt" type="EquivalentAmount2"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="AnyBICDec2014Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Authorisation1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="Authorisation1Code"/>
+			<xs:element name="Prtry" type="Max128Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="Authorisation1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AUTH"/>
+			<xs:enumeration value="FDET"/>
+			<xs:enumeration value="FSUM"/>
+			<xs:enumeration value="ILEV"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BaseOneRate">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="11"/>
+			<xs:fractionDigits value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BatchBookingIndicator">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+	<xs:simpleType name="BICFIDec2014Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18"/>
+			<xs:element name="BrnchId" type="BranchData3" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="BranchAndFinancialInstitutionIdentification6">
+				<xs:sequence>
+					<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18_pain001_ch"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="BranchAndFinancialInstitutionIdentification6">
+				<xs:sequence>
+					<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18_pain001_ch_2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="BranchAndFinancialInstitutionIdentification6">
+				<xs:sequence>
+					<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18_pain001_ch_3"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="BranchAndFinancialInstitutionIdentification6">
+				<xs:sequence>
+					<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18_pain001_ch_4"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BranchData3">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text" minOccurs="0"/>
+			<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="PostalAddress24" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38">
+		<xs:sequence>
+			<xs:element name="Id" type="AccountIdentification4Choice"/>
+			<xs:element name="Tp" type="CashAccountType2Choice" minOccurs="0"/>
+			<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+			<xs:element name="Nm" type="Max70Text" minOccurs="0"/>
+			<xs:element name="Prxy" type="ProxyAccountIdentification1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="CashAccount38">
+				<xs:sequence>
+					<xs:element name="Id" type="AccountIdentification4Choice_pain001_ch"/>
+					<xs:element name="Tp" type="CashAccountType2Choice" minOccurs="0"/>
+					<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+					<xs:element name="Prxy" type="ProxyAccountIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="CashAccount38">
+				<xs:sequence>
+					<xs:element name="Id" type="AccountIdentification4Choice_pain001_ch"/>
+					<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+					<xs:element name="Prxy" type="ProxyAccountIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="CashAccount38">
+				<xs:sequence>
+					<xs:element name="Id" type="AccountIdentification4Choice"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="CashAccount38">
+				<xs:sequence>
+					<xs:element name="Id" type="AccountIdentification4Choice_pain001_ch"/>
+					<xs:element name="Prxy" type="ProxyAccountIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CashAccountType2Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalCashAccountType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CategoryPurpose1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalCategoryPurpose1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CategoryPurpose1Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="CategoryPurpose1Choice">
+				<xs:choice>
+					<xs:element name="Cd" type="ExternalCategoryPurpose1Code"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="ChargeBearerType1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRED"/>
+			<xs:enumeration value="DEBT"/>
+			<xs:enumeration value="SHAR"/>
+			<xs:enumeration value="SLEV"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Cheque11">
+		<xs:sequence>
+			<xs:element name="ChqTp" type="ChequeType2Code" minOccurs="0"/>
+			<xs:element name="ChqNb" type="Max35Text" minOccurs="0"/>
+			<xs:element name="ChqFr" type="NameAndAddress16" minOccurs="0"/>
+			<xs:element name="DlvryMtd" type="ChequeDeliveryMethod1Choice" minOccurs="0"/>
+			<xs:element name="DlvrTo" type="NameAndAddress16" minOccurs="0"/>
+			<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0"/>
+			<xs:element name="ChqMtrtyDt" type="ISODate" minOccurs="0"/>
+			<xs:element name="FrmsCd" type="Max35Text" minOccurs="0"/>
+			<xs:element name="MemoFld" type="Max35Text" minOccurs="0" maxOccurs="2"/>
+			<xs:element name="RgnlClrZone" type="Max35Text" minOccurs="0"/>
+			<xs:element name="PrtLctn" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Sgntr" type="Max70Text" minOccurs="0" maxOccurs="5"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Cheque11_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Cheque11">
+				<xs:sequence>
+					<xs:element name="ChqTp" type="ChequeType2Code" minOccurs="0"/>
+					<xs:element name="DlvryMtd" type="ChequeDeliveryMethod1Choice" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="ChequeDelivery1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRCD"/>
+			<xs:enumeration value="CRDB"/>
+			<xs:enumeration value="CRFA"/>
+			<xs:enumeration value="MLCD"/>
+			<xs:enumeration value="MLDB"/>
+			<xs:enumeration value="MLFA"/>
+			<xs:enumeration value="PUCD"/>
+			<xs:enumeration value="PUDB"/>
+			<xs:enumeration value="PUFA"/>
+			<xs:enumeration value="RGCD"/>
+			<xs:enumeration value="RGDB"/>
+			<xs:enumeration value="RGFA"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ChequeDeliveryMethod1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ChequeDelivery1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="ChequeType2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BCHQ"/>
+			<xs:enumeration value="CCCH"/>
+			<xs:enumeration value="CCHQ"/>
+			<xs:enumeration value="DRFT"/>
+			<xs:enumeration value="ELDR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ClearingSystemIdentification2Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalClearingSystemIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ClearingSystemIdentification2Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="ClearingSystemIdentification2Choice">
+				<xs:choice>
+					<xs:element name="Cd" type="ExternalClearingSystemIdentification1Code"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ClearingSystemMemberIdentification2">
+		<xs:sequence>
+			<xs:element name="ClrSysId" type="ClearingSystemIdentification2Choice" minOccurs="0"/>
+			<xs:element name="MmbId" type="Max35Text"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ClearingSystemMemberIdentification2_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="ClearingSystemMemberIdentification2">
+				<xs:sequence>
+					<xs:element name="ClrSysId" type="ClearingSystemIdentification2Choice_pain001_ch" minOccurs="0"/>
+					<xs:element name="MmbId" type="Max35Text"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Contact4">
+		<xs:sequence>
+			<xs:element name="NmPrfx" type="NamePrefix2Code" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PhneNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="MobNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="FaxNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="EmailAdr" type="Max2048Text" minOccurs="0"/>
+			<xs:element name="EmailPurp" type="Max35Text" minOccurs="0"/>
+			<xs:element name="JobTitl" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Rspnsblty" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+			<xs:element name="Othr" type="OtherContact1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="PrefrdMtd" type="PreferredContactMethod1Code" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Contact4_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Contact4">
+				<xs:sequence>
+					<xs:element name="Othr" type="OtherContact1_pain001_ch" minOccurs="0" maxOccurs="4"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="CountryCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CreditDebitCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRDT"/>
+			<xs:enumeration value="DBIT"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="CreditorReferenceInformation2">
+		<xs:sequence>
+			<xs:element name="Tp" type="CreditorReferenceType2" minOccurs="0"/>
+			<xs:element name="Ref" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="DocumentType3Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceType2">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="CreditorReferenceType1Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditTransferTransaction34">
+		<xs:sequence>
+			<xs:element name="PmtId" type="PaymentIdentification6"/>
+			<xs:element name="PmtTpInf" type="PaymentTypeInformation26" minOccurs="0"/>
+			<xs:element name="Amt" type="AmountType4Choice"/>
+			<xs:element name="XchgRateInf" type="ExchangeRate1" minOccurs="0"/>
+			<xs:element name="ChrgBr" type="ChargeBearerType1Code" minOccurs="0"/>
+			<xs:element name="ChqInstr" type="Cheque11" minOccurs="0"/>
+			<xs:element name="UltmtDbtr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="IntrmyAgt1" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="IntrmyAgt1Acct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="IntrmyAgt2" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="IntrmyAgt2Acct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="IntrmyAgt3" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="IntrmyAgt3Acct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="CdtrAgt" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="CdtrAgtAcct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="Cdtr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="CdtrAcct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="UltmtCdtr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="InstrForCdtrAgt" type="InstructionForCreditorAgent1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InstrForDbtrAgt" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Purp" type="Purpose2Choice" minOccurs="0"/>
+			<xs:element name="RgltryRptg" type="RegulatoryReporting3" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="Tax" type="TaxInformation8" minOccurs="0"/>
+			<xs:element name="RltdRmtInf" type="RemittanceLocation7" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="RmtInf" type="RemittanceInformation16" minOccurs="0"/>
+			<xs:element name="SplmtryData" type="SupplementaryData1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditTransferTransaction34_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="CreditTransferTransaction34">
+				<xs:sequence>
+					<xs:element name="PmtId" type="PaymentIdentification6_pain001_ch"/>
+					<xs:element name="PmtTpInf" type="PaymentTypeInformation26_pain001_ch_2" minOccurs="0"/>
+					<xs:element name="Amt" type="AmountType4Choice"/>
+					<xs:element name="XchgRateInf" type="ExchangeRate1" minOccurs="0"/>
+					<xs:element name="ChrgBr" type="ChargeBearerType1Code" minOccurs="0"/>
+					<xs:element name="ChqInstr" type="Cheque11_pain001_ch" minOccurs="0"/>
+					<xs:element name="UltmtDbtr" type="PartyIdentification135_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="IntrmyAgt1" type="BranchAndFinancialInstitutionIdentification6_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="IntrmyAgt1Acct" type="CashAccount38_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="CdtrAgt" type="BranchAndFinancialInstitutionIdentification6_pain001_ch_4" minOccurs="0"/>
+					<xs:element name="CdtrAgtAcct" type="CashAccount38_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="Cdtr" type="PartyIdentification135_pain001_ch_4" minOccurs="0"/>
+					<xs:element name="CdtrAcct" type="CashAccount38_pain001_ch_4" minOccurs="0"/>
+					<xs:element name="UltmtCdtr" type="PartyIdentification135_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="InstrForCdtrAgt" type="InstructionForCreditorAgent1" minOccurs="0" maxOccurs="2"/>
+					<xs:element name="InstrForDbtrAgt" type="Max140Text" minOccurs="0"/>
+					<xs:element name="Purp" type="Purpose2Choice_pain001_ch" minOccurs="0"/>
+					<xs:element name="RgltryRptg" type="RegulatoryReporting3" minOccurs="0" maxOccurs="10"/>
+					<xs:element name="RltdRmtInf" type="RemittanceLocation7" minOccurs="0"/>
+					<xs:element name="RmtInf" type="RemittanceInformation16_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CustomerCreditTransferInitiationV09">
+		<xs:sequence>
+			<xs:element name="GrpHdr" type="GroupHeader85"/>
+			<xs:element name="PmtInf" type="PaymentInstruction30" maxOccurs="unbounded"/>
+			<xs:element name="SplmtryData" type="SupplementaryData1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CustomerCreditTransferInitiationV09_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="CustomerCreditTransferInitiationV09">
+				<xs:sequence>
+					<xs:element name="GrpHdr" type="GroupHeader85_pain001_ch"/>
+					<xs:element name="PmtInf" type="PaymentInstruction30_pain001_ch" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DateAndDateTime2Choice">
+		<xs:choice>
+			<xs:element name="Dt" type="ISODate"/>
+			<xs:element name="DtTm" type="ISODateTime"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DateAndPlaceOfBirth1">
+		<xs:sequence>
+			<xs:element name="BirthDt" type="ISODate"/>
+			<xs:element name="PrvcOfBirth" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CityOfBirth" type="Max35Text"/>
+			<xs:element name="CtryOfBirth" type="CountryCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DatePeriod2">
+		<xs:sequence>
+			<xs:element name="FrDt" type="ISODate"/>
+			<xs:element name="ToDt" type="ISODate"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="DecimalNumber">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="17"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="DiscountAmountAndType1">
+		<xs:sequence>
+			<xs:element name="Tp" type="DiscountAmountType1Choice" minOccurs="0"/>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DiscountAmountType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalDiscountAmountType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Document">
+		<xs:sequence>
+			<xs:element name="CstmrCdtTrfInitn" type="CustomerCreditTransferInitiationV09"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentAdjustment1">
+		<xs:sequence>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+			<xs:element name="CdtDbtInd" type="CreditDebitCode" minOccurs="0"/>
+			<xs:element name="Rsn" type="Max4Text" minOccurs="0"/>
+			<xs:element name="AddtlInf" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentLineIdentification1">
+		<xs:sequence>
+			<xs:element name="Tp" type="DocumentLineType1" minOccurs="0"/>
+			<xs:element name="Nb" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RltdDt" type="ISODate" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentLineInformation1">
+		<xs:sequence>
+			<xs:element name="Id" type="DocumentLineIdentification1" maxOccurs="unbounded"/>
+			<xs:element name="Desc" type="Max2048Text" minOccurs="0"/>
+			<xs:element name="Amt" type="RemittanceAmount3" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentLineType1">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="DocumentLineType1Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentLineType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalDocumentLineType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="DocumentType3Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DISP"/>
+			<xs:enumeration value="FXDR"/>
+			<xs:enumeration value="PUOR"/>
+			<xs:enumeration value="RADM"/>
+			<xs:enumeration value="RPIN"/>
+			<xs:enumeration value="SCOR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentType6Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AROI"/>
+			<xs:enumeration value="BOLD"/>
+			<xs:enumeration value="CINV"/>
+			<xs:enumeration value="CMCN"/>
+			<xs:enumeration value="CNFA"/>
+			<xs:enumeration value="CREN"/>
+			<xs:enumeration value="DEBN"/>
+			<xs:enumeration value="DISP"/>
+			<xs:enumeration value="DNFA"/>
+			<xs:enumeration value="HIRI"/>
+			<xs:enumeration value="MSIN"/>
+			<xs:enumeration value="PUOR"/>
+			<xs:enumeration value="SBIN"/>
+			<xs:enumeration value="SOAC"/>
+			<xs:enumeration value="TSUT"/>
+			<xs:enumeration value="VCHR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Document_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Document">
+				<xs:sequence>
+					<xs:element name="CstmrCdtTrfInitn" type="CustomerCreditTransferInitiationV09_pain001_ch"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EquivalentAmount2">
+		<xs:sequence>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+			<xs:element name="CcyOfTrf" type="ActiveOrHistoricCurrencyCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="Exact4AlphaNumericText">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[a-zA-Z0-9]{4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ExchangeRate1">
+		<xs:sequence>
+			<xs:element name="UnitCcy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+			<xs:element name="XchgRate" type="BaseOneRate" minOccurs="0"/>
+			<xs:element name="RateTp" type="ExchangeRateType1Code" minOccurs="0"/>
+			<xs:element name="CtrctId" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="ExchangeRateType1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AGRD"/>
+			<xs:enumeration value="SALE"/>
+			<xs:enumeration value="SPOT"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalAccountIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalCashAccountType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalCategoryPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalClearingSystemIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="5"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalDiscountAmountType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalDocumentLineType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalFinancialInstitutionIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalGarnishmentType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalLocalInstrument1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalOrganisationIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPersonIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalProxyAccountType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalServiceLevel1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalTaxAmountType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="FinancialIdentificationSchemeName1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalFinancialInstitutionIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18">
+		<xs:sequence>
+			<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+			<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2" minOccurs="0"/>
+			<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="PostalAddress24" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericFinancialIdentification1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="FinancialInstitutionIdentification18">
+				<xs:sequence>
+					<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+					<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericFinancialIdentification1_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="FinancialInstitutionIdentification18">
+				<xs:sequence>
+					<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+					<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2_pain001_ch" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="FinancialInstitutionIdentification18">
+				<xs:sequence>
+					<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+					<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2_pain001_ch" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_4" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="FinancialInstitutionIdentification18">
+				<xs:sequence>
+					<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+					<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2_pain001_ch" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericFinancialIdentification1_pain001_ch_2" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Garnishment3">
+		<xs:sequence>
+			<xs:element name="Tp" type="GarnishmentType1"/>
+			<xs:element name="Grnshee" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="GrnshmtAdmstr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="RefNb" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+			<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="FmlyMdclInsrncInd" type="TrueFalseIndicator" minOccurs="0"/>
+			<xs:element name="MplyeeTermntnInd" type="TrueFalseIndicator" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Garnishment3_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Garnishment3">
+				<xs:sequence>
+					<xs:element name="Tp" type="GarnishmentType1"/>
+					<xs:element name="Grnshee" type="PartyIdentification135_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="GrnshmtAdmstr" type="PartyIdentification135_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="RefNb" type="Max140Text" minOccurs="0"/>
+					<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+					<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+					<xs:element name="FmlyMdclInsrncInd" type="TrueFalseIndicator" minOccurs="0"/>
+					<xs:element name="MplyeeTermntnInd" type="TrueFalseIndicator" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GarnishmentType1">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="GarnishmentType1Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GarnishmentType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalGarnishmentType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="GenericAccountIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max34Text"/>
+			<xs:element name="SchmeNm" type="AccountSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericAccountIdentification1_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="GenericAccountIdentification1">
+				<xs:sequence>
+					<xs:element name="Id" type="Max34Text"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GenericFinancialIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="FinancialIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericFinancialIdentification1_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="GenericFinancialIdentification1">
+				<xs:sequence>
+					<xs:element name="Id" type="Max35Text"/>
+					<xs:element name="SchmeNm" type="FinancialIdentificationSchemeName1Choice" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GenericFinancialIdentification1_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="GenericFinancialIdentification1">
+				<xs:sequence>
+					<xs:element name="Id" type="Max35Text"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GenericIdentification30">
+		<xs:sequence>
+			<xs:element name="Id" type="Exact4AlphaNumericText"/>
+			<xs:element name="Issr" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericOrganisationIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="OrganisationIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericPersonIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="PersonIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GroupHeader85">
+		<xs:sequence>
+			<xs:element name="MsgId" type="Max35Text"/>
+			<xs:element name="CreDtTm" type="ISODateTime"/>
+			<xs:element name="Authstn" type="Authorisation1Choice" minOccurs="0" maxOccurs="2"/>
+			<xs:element name="NbOfTxs" type="Max15NumericText"/>
+			<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+			<xs:element name="InitgPty" type="PartyIdentification135"/>
+			<xs:element name="FwdgAgt" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GroupHeader85_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="GroupHeader85">
+				<xs:sequence>
+					<xs:element name="MsgId" type="Max35Text_pain001_ch"/>
+					<xs:element name="CreDtTm" type="ISODateTime"/>
+					<xs:element name="NbOfTxs" type="Max15NumericText"/>
+					<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+					<xs:element name="InitgPty" type="PartyIdentification135_pain001_ch"/>
+					<xs:element name="FwdgAgt" type="BranchAndFinancialInstitutionIdentification6_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="IBAN2007Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Instruction3Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CHQB"/>
+			<xs:enumeration value="HOLD"/>
+			<xs:enumeration value="PHOB"/>
+			<xs:enumeration value="TELB"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="InstructionForCreditorAgent1">
+		<xs:sequence>
+			<xs:element name="Cd" type="Instruction3Code" minOccurs="0"/>
+			<xs:element name="InstrInf" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="ISODate">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="ISODateTime">
+		<xs:restriction base="xs:dateTime"/>
+	</xs:simpleType>
+	<xs:simpleType name="LEIIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z0-9]{18,18}[0-9]{2,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="LocalInstrument2Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalLocalInstrument1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="Max10Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max128Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="128"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max140Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="140"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max15NumericText">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max16Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="16"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max2048Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="2048"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max34Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="34"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max350Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="350"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max35Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max35Text_pain001_ch">
+		<xs:restriction base="Max35Text">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+			<xs:pattern value="([A-Za-z0-9]|[+|\?|/|\-|:|\(|\)|\.|,|&apos;|\p{Zs}])*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max4Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max70Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="70"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="NameAndAddress16">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max140Text"/>
+			<xs:element name="Adr" type="PostalAddress24"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="NamePrefix2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DOCT"/>
+			<xs:enumeration value="MADM"/>
+			<xs:enumeration value="MIKS"/>
+			<xs:enumeration value="MISS"/>
+			<xs:enumeration value="MIST"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Number">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="OrganisationIdentification29">
+		<xs:sequence>
+			<xs:element name="AnyBIC" type="AnyBICDec2014Identifier" minOccurs="0"/>
+			<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericOrganisationIdentification1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentification29_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="OrganisationIdentification29">
+				<xs:sequence>
+					<xs:element name="AnyBIC" type="AnyBICDec2014Identifier" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericOrganisationIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentification29_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="OrganisationIdentification29">
+				<xs:sequence>
+					<xs:element name="AnyBIC" type="AnyBICDec2014Identifier" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericOrganisationIdentification1" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentificationSchemeName1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalOrganisationIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="OtherContact1">
+		<xs:sequence>
+			<xs:element name="ChanlTp" type="Max4Text"/>
+			<xs:element name="Id" type="Max128Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OtherContact1_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="OtherContact1">
+				<xs:sequence>
+					<xs:element name="ChanlTp" type="Max4Text"/>
+					<xs:element name="Id" type="Max128Text"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Party38Choice">
+		<xs:choice>
+			<xs:element name="OrgId" type="OrganisationIdentification29"/>
+			<xs:element name="PrvtId" type="PersonIdentification13"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Party38Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Party38Choice">
+				<xs:choice>
+					<xs:element name="OrgId" type="OrganisationIdentification29_pain001_ch"/>
+					<xs:element name="PrvtId" type="PersonIdentification13_pain001_ch"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Party38Choice_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="Party38Choice">
+				<xs:choice>
+					<xs:element name="OrgId" type="OrganisationIdentification29_pain001_ch_2"/>
+					<xs:element name="PrvtId" type="PersonIdentification13_pain001_ch_2"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="PostalAddress24" minOccurs="0"/>
+			<xs:element name="Id" type="Party38Choice" minOccurs="0"/>
+			<xs:element name="CtryOfRes" type="CountryCode" minOccurs="0"/>
+			<xs:element name="CtctDtls" type="Contact4" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch" minOccurs="0"/>
+					<xs:element name="CtctDtls" type="Contact4_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_2" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch_5">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch_2" minOccurs="0"/>
+					<xs:element name="CtryOfRes" type="CountryCode" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PaymentIdentification6">
+		<xs:sequence>
+			<xs:element name="InstrId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="EndToEndId" type="Max35Text"/>
+			<xs:element name="UETR" type="UUIDv4Identifier" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentIdentification6_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PaymentIdentification6">
+				<xs:sequence>
+					<xs:element name="InstrId" type="Max35Text_pain001_ch" minOccurs="0"/>
+					<xs:element name="EndToEndId" type="Max35Text_pain001_ch"/>
+					<xs:element name="UETR" type="UUIDv4Identifier" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PaymentInstruction30">
+		<xs:sequence>
+			<xs:element name="PmtInfId" type="Max35Text"/>
+			<xs:element name="PmtMtd" type="PaymentMethod3Code"/>
+			<xs:element name="BtchBookg" type="BatchBookingIndicator" minOccurs="0"/>
+			<xs:element name="NbOfTxs" type="Max15NumericText" minOccurs="0"/>
+			<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+			<xs:element name="PmtTpInf" type="PaymentTypeInformation26" minOccurs="0"/>
+			<xs:element name="ReqdExctnDt" type="DateAndDateTime2Choice"/>
+			<xs:element name="PoolgAdjstmntDt" type="ISODate" minOccurs="0"/>
+			<xs:element name="Dbtr" type="PartyIdentification135"/>
+			<xs:element name="DbtrAcct" type="CashAccount38"/>
+			<xs:element name="DbtrAgt" type="BranchAndFinancialInstitutionIdentification6"/>
+			<xs:element name="DbtrAgtAcct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="InstrForDbtrAgt" type="Max140Text" minOccurs="0"/>
+			<xs:element name="UltmtDbtr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="ChrgBr" type="ChargeBearerType1Code" minOccurs="0"/>
+			<xs:element name="ChrgsAcct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="ChrgsAcctAgt" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="CdtTrfTxInf" type="CreditTransferTransaction34" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentInstruction30_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PaymentInstruction30">
+				<xs:sequence>
+					<xs:element name="PmtInfId" type="Max35Text_pain001_ch"/>
+					<xs:element name="PmtMtd" type="PaymentMethod3Code"/>
+					<xs:element name="BtchBookg" type="BatchBookingIndicator" minOccurs="0"/>
+					<xs:element name="NbOfTxs" type="Max15NumericText" minOccurs="0"/>
+					<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+					<xs:element name="PmtTpInf" type="PaymentTypeInformation26_pain001_ch" minOccurs="0"/>
+					<xs:element name="ReqdExctnDt" type="DateAndDateTime2Choice"/>
+					<xs:element name="Dbtr" type="PartyIdentification135_pain001_ch_2"/>
+					<xs:element name="DbtrAcct" type="CashAccount38_pain001_ch"/>
+					<xs:element name="DbtrAgt" type="BranchAndFinancialInstitutionIdentification6_pain001_ch_2"/>
+					<xs:element name="InstrForDbtrAgt" type="Max140Text" minOccurs="0"/>
+					<xs:element name="UltmtDbtr" type="PartyIdentification135_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="ChrgBr" type="ChargeBearerType1Code" minOccurs="0"/>
+					<xs:element name="ChrgsAcct" type="CashAccount38_pain001_ch_2" minOccurs="0"/>
+					<xs:element name="CdtTrfTxInf" type="CreditTransferTransaction34_pain001_ch" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="PaymentMethod3Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CHK"/>
+			<xs:enumeration value="TRA"/>
+			<xs:enumeration value="TRF"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PaymentTypeInformation26">
+		<xs:sequence>
+			<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0"/>
+			<xs:element name="SvcLvl" type="ServiceLevel8Choice" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="LclInstrm" type="LocalInstrument2Choice" minOccurs="0"/>
+			<xs:element name="CtgyPurp" type="CategoryPurpose1Choice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentTypeInformation26_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PaymentTypeInformation26">
+				<xs:sequence>
+					<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0"/>
+					<xs:element name="SvcLvl" type="ServiceLevel8Choice" minOccurs="0" maxOccurs="3"/>
+					<xs:element name="LclInstrm" type="LocalInstrument2Choice" minOccurs="0"/>
+					<xs:element name="CtgyPurp" type="CategoryPurpose1Choice_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PaymentTypeInformation26_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="PaymentTypeInformation26">
+				<xs:sequence>
+					<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0"/>
+					<xs:element name="SvcLvl" type="ServiceLevel8Choice" minOccurs="0" maxOccurs="3"/>
+					<xs:element name="LclInstrm" type="LocalInstrument2Choice" minOccurs="0"/>
+					<xs:element name="CtgyPurp" type="CategoryPurpose1Choice" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="PercentageRate">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="11"/>
+			<xs:fractionDigits value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PersonIdentification13">
+		<xs:sequence>
+			<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth1" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericPersonIdentification1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentification13_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PersonIdentification13">
+				<xs:sequence>
+					<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth1" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericPersonIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentification13_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="PersonIdentification13">
+				<xs:sequence>
+					<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth1" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericPersonIdentification1" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentificationSchemeName1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalPersonIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="PhoneNumber">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\+[0-9]{1,3}-[0-9()+\-]{1,30}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PostalAddress24">
+		<xs:sequence>
+			<xs:element name="AdrTp" type="AddressType3Choice" minOccurs="0"/>
+			<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+			<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+			<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+			<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+			<xs:element name="BldgNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Flr" type="Max70Text" minOccurs="0"/>
+			<xs:element name="PstBx" type="Max16Text" minOccurs="0"/>
+			<xs:element name="Room" type="Max70Text" minOccurs="0"/>
+			<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+			<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TwnLctnNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="DstrctNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+			<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="7"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="7"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="AdrTp" type="AddressType3Choice" minOccurs="0"/>
+					<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+					<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+					<xs:element name="BldgNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Flr" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstBx" type="Max16Text" minOccurs="0"/>
+					<xs:element name="Room" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+					<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="TwnLctnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="DstrctNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+					<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+					<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+					<xs:element name="BldgNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Flr" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstBx" type="Max16Text" minOccurs="0"/>
+					<xs:element name="Room" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+					<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="TwnLctnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="DstrctNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+					<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch_5">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+					<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+					<xs:element name="BldgNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Flr" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstBx" type="Max16Text" minOccurs="0"/>
+					<xs:element name="Room" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+					<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="TwnLctnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="DstrctNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="PreferredContactMethod1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CELL"/>
+			<xs:enumeration value="FAXX"/>
+			<xs:enumeration value="LETT"/>
+			<xs:enumeration value="MAIL"/>
+			<xs:enumeration value="PHON"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Priority2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="HIGH"/>
+			<xs:enumeration value="NORM"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ProxyAccountIdentification1">
+		<xs:sequence>
+			<xs:element name="Tp" type="ProxyAccountType1Choice" minOccurs="0"/>
+			<xs:element name="Id" type="Max2048Text"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ProxyAccountType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalProxyAccountType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Purpose2Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalPurpose1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Purpose2Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Purpose2Choice">
+				<xs:choice>
+					<xs:element name="Cd" type="ExternalPurpose1Code"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentInformation7">
+		<xs:sequence>
+			<xs:element name="Tp" type="ReferredDocumentType4" minOccurs="0"/>
+			<xs:element name="Nb" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RltdDt" type="ISODate" minOccurs="0"/>
+			<xs:element name="LineDtls" type="DocumentLineInformation1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentType3Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="DocumentType6Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentType4">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="ReferredDocumentType3Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RegulatoryAuthority2">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RegulatoryReporting3">
+		<xs:sequence>
+			<xs:element name="DbtCdtRptgInd" type="RegulatoryReportingType1Code" minOccurs="0"/>
+			<xs:element name="Authrty" type="RegulatoryAuthority2" minOccurs="0"/>
+			<xs:element name="Dtls" type="StructuredRegulatoryReporting3" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="RegulatoryReportingType1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BOTH"/>
+			<xs:enumeration value="CRED"/>
+			<xs:enumeration value="DEBT"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="RemittanceAmount2">
+		<xs:sequence>
+			<xs:element name="DuePyblAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="DscntApldAmt" type="DiscountAmountAndType1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CdtNoteAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TaxAmt" type="TaxAmountAndType1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AdjstmntAmtAndRsn" type="DocumentAdjustment1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceAmount3">
+		<xs:sequence>
+			<xs:element name="DuePyblAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="DscntApldAmt" type="DiscountAmountAndType1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CdtNoteAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TaxAmt" type="TaxAmountAndType1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AdjstmntAmtAndRsn" type="DocumentAdjustment1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceInformation16">
+		<xs:sequence>
+			<xs:element name="Ustrd" type="Max140Text" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Strd" type="StructuredRemittanceInformation16" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceInformation16_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="RemittanceInformation16">
+				<xs:sequence>
+					<xs:element name="Ustrd" type="Max140Text" minOccurs="0"/>
+					<xs:element name="Strd" type="StructuredRemittanceInformation16_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RemittanceLocation7">
+		<xs:sequence>
+			<xs:element name="RmtId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RmtLctnDtls" type="RemittanceLocationData1" minOccurs="0" maxOccurs="2"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceLocationData1">
+		<xs:sequence>
+			<xs:element name="Mtd" type="RemittanceLocationMethod2Code"/>
+			<xs:element name="ElctrncAdr" type="Max2048Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="NameAndAddress16" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="RemittanceLocationMethod2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EDIC"/>
+			<xs:enumeration value="EMAL"/>
+			<xs:enumeration value="FAXI"/>
+			<xs:enumeration value="POST"/>
+			<xs:enumeration value="SMSM"/>
+			<xs:enumeration value="URID"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ServiceLevel8Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalServiceLevel1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="SPSText">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[\p{IsBasicLatin}\p{IsLatin-1Supplement}\p{IsLatinExtended-A}€ȘșȚț-[\p{C}]]+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="StructuredRegulatoryReporting3">
+		<xs:sequence>
+			<xs:element name="Tp" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+			<xs:element name="Cd" type="Max10Text" minOccurs="0"/>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Inf" type="Max35Text" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructuredRemittanceInformation16">
+		<xs:sequence>
+			<xs:element name="RfrdDocInf" type="ReferredDocumentInformation7" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RfrdDocAmt" type="RemittanceAmount2" minOccurs="0"/>
+			<xs:element name="CdtrRefInf" type="CreditorReferenceInformation2" minOccurs="0"/>
+			<xs:element name="Invcr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="Invcee" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="TaxRmt" type="TaxInformation7" minOccurs="0"/>
+			<xs:element name="GrnshmtRmt" type="Garnishment3" minOccurs="0"/>
+			<xs:element name="AddtlRmtInf" type="Max140Text" minOccurs="0" maxOccurs="3"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructuredRemittanceInformation16_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="StructuredRemittanceInformation16">
+				<xs:sequence>
+					<xs:element name="RfrdDocInf" type="ReferredDocumentInformation7" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="RfrdDocAmt" type="RemittanceAmount2" minOccurs="0"/>
+					<xs:element name="CdtrRefInf" type="CreditorReferenceInformation2" minOccurs="0"/>
+					<xs:element name="Invcr" type="PartyIdentification135_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="Invcee" type="PartyIdentification135_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="TaxRmt" type="TaxInformation7" minOccurs="0"/>
+					<xs:element name="GrnshmtRmt" type="Garnishment3_pain001_ch" minOccurs="0"/>
+					<xs:element name="AddtlRmtInf" type="Max140Text" minOccurs="0" maxOccurs="3"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SupplementaryData1">
+		<xs:sequence>
+			<xs:element name="PlcAndNm" type="Max350Text" minOccurs="0"/>
+			<xs:element name="Envlp" type="SupplementaryDataEnvelope1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SupplementaryDataEnvelope1">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxAmount2">
+		<xs:sequence>
+			<xs:element name="Rate" type="PercentageRate" minOccurs="0"/>
+			<xs:element name="TaxblBaseAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TtlAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Dtls" type="TaxRecordDetails2" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxAmountAndType1">
+		<xs:sequence>
+			<xs:element name="Tp" type="TaxAmountType1Choice" minOccurs="0"/>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxAmountType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalTaxAmountType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TaxAuthorisation1">
+		<xs:sequence>
+			<xs:element name="Titl" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxInformation7">
+		<xs:sequence>
+			<xs:element name="Cdtr" type="TaxParty1" minOccurs="0"/>
+			<xs:element name="Dbtr" type="TaxParty2" minOccurs="0"/>
+			<xs:element name="UltmtDbtr" type="TaxParty2" minOccurs="0"/>
+			<xs:element name="AdmstnZone" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RefNb" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Mtd" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TtlTaxblBaseAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TtlTaxAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+			<xs:element name="SeqNb" type="Number" minOccurs="0"/>
+			<xs:element name="Rcrd" type="TaxRecord2" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxInformation8">
+		<xs:sequence>
+			<xs:element name="Cdtr" type="TaxParty1" minOccurs="0"/>
+			<xs:element name="Dbtr" type="TaxParty2" minOccurs="0"/>
+			<xs:element name="AdmstnZone" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RefNb" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Mtd" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TtlTaxblBaseAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TtlTaxAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+			<xs:element name="SeqNb" type="Number" minOccurs="0"/>
+			<xs:element name="Rcrd" type="TaxRecord2" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxParty1">
+		<xs:sequence>
+			<xs:element name="TaxId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RegnId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TaxTp" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxParty2">
+		<xs:sequence>
+			<xs:element name="TaxId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RegnId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TaxTp" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Authstn" type="TaxAuthorisation1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxPeriod2">
+		<xs:sequence>
+			<xs:element name="Yr" type="ISODate" minOccurs="0"/>
+			<xs:element name="Tp" type="TaxRecordPeriod1Code" minOccurs="0"/>
+			<xs:element name="FrToDt" type="DatePeriod2" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxRecord2">
+		<xs:sequence>
+			<xs:element name="Tp" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Ctgy" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CtgyDtls" type="Max35Text" minOccurs="0"/>
+			<xs:element name="DbtrSts" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CertId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="FrmsCd" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Prd" type="TaxPeriod2" minOccurs="0"/>
+			<xs:element name="TaxAmt" type="TaxAmount2" minOccurs="0"/>
+			<xs:element name="AddtlInf" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxRecordDetails2">
+		<xs:sequence>
+			<xs:element name="Prd" type="TaxPeriod2" minOccurs="0"/>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="TaxRecordPeriod1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="HLF1"/>
+			<xs:enumeration value="HLF2"/>
+			<xs:enumeration value="MM01"/>
+			<xs:enumeration value="MM02"/>
+			<xs:enumeration value="MM03"/>
+			<xs:enumeration value="MM04"/>
+			<xs:enumeration value="MM05"/>
+			<xs:enumeration value="MM06"/>
+			<xs:enumeration value="MM07"/>
+			<xs:enumeration value="MM08"/>
+			<xs:enumeration value="MM09"/>
+			<xs:enumeration value="MM10"/>
+			<xs:enumeration value="MM11"/>
+			<xs:enumeration value="MM12"/>
+			<xs:enumeration value="QTR1"/>
+			<xs:enumeration value="QTR2"/>
+			<xs:enumeration value="QTR3"/>
+			<xs:enumeration value="QTR4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TrueFalseIndicator">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+	<xs:simpleType name="UUIDv4Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/lib/sps_king/account.rb
+++ b/lib/sps_king/account.rb
@@ -18,9 +18,18 @@ module SPS
                    IBANValidator,
                    message: "%{value} is invalid"
 
-    def schema_version
-      ( @schema_version || :V3 ).to_sym
+    def schema_version( type )
+      ( @schema_version || method(type).call  ).to_sym
     end
+
+    def direct_debit_schema
+      :pain_008_001_02_ch_03
+    end
+
+    def credit_transfers_schema
+      :pain_001_001_03_ch_02
+    end
+
 
     def initialize(attributes = {})
       attributes.each do |name, value|

--- a/lib/sps_king/account.rb
+++ b/lib/sps_king/account.rb
@@ -8,7 +8,8 @@ module SPS
 
     attr_accessor :name,
                   :iban,
-                  :bic
+                  :bic,
+                  :schema_version
 
     convert :name, to: :text
 
@@ -16,6 +17,10 @@ module SPS
     validates_with BICValidator,
                    IBANValidator,
                    message: "%{value} is invalid"
+
+    def schema_version
+      ( @schema_version || :V3 ).to_sym
+    end
 
     def initialize(attributes = {})
       attributes.each do |name, value|

--- a/lib/sps_king/account/address.rb
+++ b/lib/sps_king/account/address.rb
@@ -59,7 +59,7 @@ module SPS
 
 
     def initialize(attributes = {})
-      @version = attributes.delete(:version) || :V3
+      @version = attributes.delete(:version) || :pain_001_001_03_ch_02
       attributes.each do |name, value|
         public_send("#{name}=", value)
       end
@@ -80,15 +80,15 @@ module SPS
       end
 
       def address_with_version
-        if @version == :V3
-          verify_v3_address
-        else
+        if @version == :pain_001_001_09_ch_03
           verify_v9_address
+        else
+          verify_v3_address
         end
       end
 
       def verify_v3_address
-        errors.add(:address_line2, :blank) if address_line2.blank? && town_name.blank? 
+        errors.add(:address_line2, :blank) if address_line2.blank? && town_name.blank?
         errors.add(:town_name, :blank) if town_name.blank? && address_line2.blank?
       end
 

--- a/lib/sps_king/account/address.rb
+++ b/lib/sps_king/account/address.rb
@@ -6,36 +6,60 @@ module SPS
     include ActiveModel::Validations
     extend Converter
 
+    attr_accessor :schema_version
+
     attr_accessor :street_name,
                   :building_number,
                   :post_code,
                   :town_name,
                   :country_code,
                   :address_line1,
-                  :address_line2
+                  :address_line2,
+                  :department,
+                  :sub_department,
+                  :building_name,
+                  :floor,
+                  :post_box,
+                  :room,
+                  :town_location_name,
+                  :district_name,
+                  :country_subdivision,
+                  :address_line1,
+                  :address_lne2
 
-    convert :street_name,     to: :text
-    convert :building_number, to: :text
-    convert :post_code,       to: :text
-    convert :town_name,       to: :text
-    convert :country_code,    to: :text
-    convert :address_line1,   to: :text
-    convert :address_line2,   to: :text
+    convert :department,         to: :text
+    convert :sub_department,     to: :text
+    convert :street_name,        to: :text
+    convert :building_number,    to: :text
+    convert :building_name,      to: :text
+    convert :floor,              to: :text
+    convert :post_box,           to: :text
+    convert :room,               to: :text
+    convert :post_code,          to: :text
+    convert :town_name,          to: :text
+    convert :town_location_name, to: :text
+    convert :district_name,      to: :text
+    convert :country_subdivision,to: :text
+    convert :country_code,       to: :text
+    convert :address_line1,      to: :text
+    convert :address_line2,      to: :text
 
     validates :street_name,     length: { maximum: 70 }
     validates :building_number, length: { maximum: 16 }
+    validates :building_name,   length: { maximum: 35 }
+    validates :floor,           length: { maximum: 70 }
+    validates :post_box,        length: { maximum: 16 }
+    validates :room,            length: { maximum: 70 }
     validates :post_code,       length: { maximum: 16 }
     validates :town_name,       length: { maximum: 35 }
+    validates :country_code,    presence: true, format: { with: /\A[A-Z]{2}\z/ }
     validates :address_line1,   length: { maximum: 70 }
     validates :address_line2,   length: { maximum: 70 }
-    validates :country_code,
-              presence: true,
-              format:   { with: /\A[A-Z]{2}\z/ }
-    # either town_name or address_line2 must be present
-    validates :address_line2,   presence: true, if: :town_name_blank?
-    validates :town_name,       presence: true, if: :address_line2_blank?
+    validate :address_with_version
+
 
     def initialize(attributes = {})
+      @version = attributes.delete(:version) || :V3
       attributes.each do |name, value|
         public_send("#{name}=", value)
       end
@@ -43,12 +67,33 @@ module SPS
 
     private
 
-      def town_name_blank?
-        town_name.blank?
-      end
-
       def address_line2_blank?
         address_line2.blank?
+      end
+
+      def each_address_line_max70
+        Array(address_lines).each_with_index do |line, i|
+          if line.to_s.length > 70
+            errors.add(:address_lines, "AdrLine[#{i}] exceeds 70 characters")
+          end
+        end
+      end
+
+      def address_with_version
+        if @version == :V3
+          verify_v3_address
+        else
+          verify_v9_address
+        end
+      end
+
+      def verify_v3_address
+        errors.add(:address_line2, :blank) if address_line2.blank? && town_name.blank? 
+        errors.add(:town_name, :blank) if town_name.blank? && address_line2.blank?
+      end
+
+      def verify_v9_address
+        errors.add(:town_name, :blank) if town_name.blank?
       end
 
   end

--- a/lib/sps_king/converter.rb
+++ b/lib/sps_king/converter.rb
@@ -51,6 +51,16 @@ module SPS
         val.round(2) if val&.finite? && val > 0
       end
 
+      # array of text converter for AdrLine
+      def convert_array(value)
+        return [] if value.nil?
+        if value.is_a?(Array)
+          value.map { |v| convert_text(v) }.reject(&:blank?)
+        else
+          [convert_text(value)].reject(&:blank?)
+        end
+      end
+
     end
 
   end

--- a/lib/sps_king/message/credit_transfer.rb
+++ b/lib/sps_king/message/credit_transfer.rb
@@ -47,7 +47,13 @@ module SPS
                 end
               end
             end
-            builder.ReqdExctnDt(group[:requested_date].iso8601)
+            if schema_name == PAIN_001_001_09_CH_03
+              builder.ReqdExctnDt do
+                builder.Dt(group[:requested_date].iso8601)
+              end
+            else
+              builder.ReqdExctnDt(group[:requested_date].iso8601)
+            end
             builder.Dbtr do
               builder.Nm(account.name)
             end
@@ -58,7 +64,11 @@ module SPS
             end
             builder.DbtrAgt do
               builder.FinInstnId do
-                builder.BIC(account.bic)
+                if schema_name == PAIN_001_001_09_CH_03
+                  builder.BICFI(account.bic)
+                else
+                  builder.BIC(account.bic)
+                end
               end
             end
             if group[:charge_bearer]
@@ -86,7 +96,11 @@ module SPS
           if transaction.bic
             builder.CdtrAgt do
               builder.FinInstnId do
-                builder.BIC(transaction.bic)
+                if schema_name == PAIN_001_001_09_CH_03
+                  builder.BICFI(transaction.bic)
+                else
+                  builder.BIC(transaction.bic)
+                end
               end
             end
           end

--- a/lib/sps_king/message/credit_transfer.rb
+++ b/lib/sps_king/message/credit_transfer.rb
@@ -7,8 +7,8 @@ module SPS
     self.transaction_class = CreditTransferTransaction
     self.xml_main_tag = 'CstmrCdtTrfInitn'
     self.known_schemas = {
-      V3: PAIN_001_001_03_CH_02,
-      V9: PAIN_001_001_09_CH_02
+      pain_001_001_03_ch_02: PAIN_001_001_03_CH_02,
+      pain_001_001_09_ch_03: PAIN_001_001_09_CH_03
 
     }
 

--- a/lib/sps_king/message/direct_debit.rb
+++ b/lib/sps_king/message/direct_debit.rb
@@ -6,9 +6,11 @@ module SPS
     self.account_class = CreditorAccount
     self.transaction_class = DirectDebitTransaction
     self.xml_main_tag = 'CstmrDrctDbtInitn'
-    self.known_schemas = [
-      PAIN_008_001_02_CH_03
-    ]
+    self.known_schemas = {
+      V3: PAIN_008_001_02_CH_03,
+      V9: PAIN_001_001_09_CH_02
+
+    }
 
     validate do |record|
       if record.transactions.map(&:local_instrument).uniq.size > 1

--- a/lib/sps_king/message/direct_debit.rb
+++ b/lib/sps_king/message/direct_debit.rb
@@ -7,9 +7,8 @@ module SPS
     self.transaction_class = DirectDebitTransaction
     self.xml_main_tag = 'CstmrDrctDbtInitn'
     self.known_schemas = {
-      V3: PAIN_008_001_02_CH_03,
-      V9: PAIN_001_001_09_CH_02
-
+      pain_008_001_02_ch_03: PAIN_008_001_02_CH_03,
+      pain_001_001_09_ch_03: PAIN_001_001_09_CH_03
     }
 
     validate do |record|

--- a/lib/sps_king/message/direct_debit.rb
+++ b/lib/sps_king/message/direct_debit.rb
@@ -47,7 +47,7 @@ module SPS
         return iban.to_s[4..8].sub(/^0*/, '')
       end
 
-      def build_payment_informations(builder)
+      def build_payment_informations(builder, schema_name = PAIN_008_001_02_CH_03)
         # Build a PmtInf block for every group of transactions
         grouped_transactions.each do |group, transactions|
           builder.PmtInf do

--- a/lib/sps_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sps_king/transaction/credit_transfer_transaction.rb
@@ -18,7 +18,7 @@ module SPS
 
     def schema_compatible?(schema_name)
       case schema_name
-      when PAIN_001_001_03_CH_02
+      when PAIN_001_001_03_CH_02 || PAIN_001_001_09_CH_03
         !self.bic.nil?
       end
     end

--- a/lib/sps_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sps_king/transaction/credit_transfer_transaction.rb
@@ -18,7 +18,7 @@ module SPS
 
     def schema_compatible?(schema_name)
       case schema_name
-      when PAIN_001_001_03_CH_02 || PAIN_001_001_09_CH_03
+      when PAIN_001_001_03_CH_02, PAIN_001_001_09_CH_03
         !self.bic.nil?
       end
     end

--- a/spec/lib/sps_king/message/credit_transfer_spec.rb
+++ b/spec/lib/sps_king/message/credit_transfer_spec.rb
@@ -535,5 +535,41 @@ describe SPS::CreditTransfer do
         expect(subject).to include('ISO-8859-8')
       end
     end
+
+  context 'schema-specific rules for v9' do
+    subject do
+      sct = SPS::CreditTransfer.new(
+        name: 'Schuldner GmbH',
+        iban: 'CH5481230000001998736',
+        bic: 'RAIFCH22',
+        schema_version: :pain_001_001_09_ch_03
+      )
+      sca = SPS::CreditorAddress.new(
+        country_code: 'CH',
+        street_name: 'Mustergasse',
+        building_number: '123',
+        post_code: '1234'
+      )
+
+      sct.add_transaction(
+        name: 'Contoso AG',
+        bic: 'CRESCHZZ80A',
+        iban: 'CH9300762011623852957',
+        amount: 102.50,
+        reference: 'XYZ-1234/123',
+        remittance_information: 'Rechnung vom 22.08.2013',
+        creditor_address: sca
+      )
+      sct
+    end
+
+    it 'is valid with town_name in v9' do
+      subject.transactions.first.creditor_address.town_name = 'Musterstadt'
+      expect(
+        subject.to_xml(SPS::PAIN_001_001_09_CH_03)
+      ).to validate_against('pain.001.001.09.ch.03.xsd')
+    end
+  end
+
   end
 end


### PR DESCRIPTION
We have added compatibility for credit transfers v1.9 pain.001.001.09.ch.03
Here we have mainly added the new address attributes and validations. ( name attribute length accepts upto 140 chars now, earlier 70, not implemented yet )
We have maintained the v1.8 support using a new attribute in Account class i.e schema_version. 
If the client wants to use 1.9, they must provide this attribute while creating SPS::CreditTransfer.new(schema_version: :V9, ...)
If not provided then we will use V1.8. 