### PR TITLE
Add support for proprietary values in debtor account (Element für Anzeigensteuerung)

### DIFF
--- a/lib/sps_king/account/debtor_account.rb
+++ b/lib/sps_king/account/debtor_account.rb
@@ -2,5 +2,20 @@
 
 module SPS
   class DebtorAccount < Account
+
+    extend Converter
+
+    attr_accessor :proprietary
+
+    ### Proprietary values
+    # NOA No Advice
+    # SIA Single Advice
+    # CND Collective Advice No Details
+    # CWD Collective Advice With Details
+    PROPRIETARY_VALUES = %w[NOA SIA CND CWD].freeze
+
+    validates :proprietary, inclusion: PROPRIETARY_VALUES, allow_nil: true
+
+    convert :proprietary, to: :text
   end
 end

--- a/lib/sps_king/message/credit_transfer.rb
+++ b/lib/sps_king/message/credit_transfer.rb
@@ -60,6 +60,11 @@ module SPS
               builder.Id do
                 builder.IBAN(account.iban)
               end
+              if account.proprietary.present?
+                builder.Tp do
+                  builder.Prtry(account.proprietary)
+                end
+              end
             end
             builder.DbtrAgt do
               builder.FinInstnId do

--- a/spec/lib/sps_king/account/debtor_account_spec.rb
+++ b/spec/lib/sps_king/account/debtor_account_spec.rb
@@ -8,7 +8,8 @@ describe SPS::DebtorAccount do
       SPS::DebtorAccount.new(
         name: 'Gläubiger GmbH',
         bic:  'BANKDEFFXXX',
-        iban: 'DE87200500001234567890'
+        iban: 'DE87200500001234567890',
+        proprietary: 'CWD'
       )
     ).to be_valid
   end


### PR DESCRIPTION
DbtrAcct
++Tp
+++Prty

Proprietary
Element für die Anzeigensteuerung. Folgende Werte können verwendet werden:
• NOA No Advice
• SIA Single Advice
• CND Collective Advice No Details
• CWD Collective Advice With Details

See: https://www.zkb.ch/media/zkb/dokumente/sonstige/handbuch_iso_V19.pdf